### PR TITLE
Adds config object to choose which storage type to use and sets a default

### DIFF
--- a/app/src/main/java/com/onecodelabs/reminderexample/ReminderApplication.java
+++ b/app/src/main/java/com/onecodelabs/reminderexample/ReminderApplication.java
@@ -2,7 +2,6 @@ package com.onecodelabs.reminderexample;
 
 import android.app.Application;
 
-import com.onecodelabs.reminderexample.model.Question;
 import com.onecodelabs.reminderexample.retrofit.QuestionService;
 
 import retrofit2.Retrofit;

--- a/reminder/src/main/java/com/onecodelabs/reminderexample/Reminder.java
+++ b/reminder/src/main/java/com/onecodelabs/reminderexample/Reminder.java
@@ -2,9 +2,12 @@ package com.onecodelabs.reminderexample;
 
 import android.app.Activity;
 import android.app.Application;
+import android.support.annotation.NonNull;
 
 import com.onecodelabs.reminderexample.bundle.ReminderBundle;
 import com.onecodelabs.reminderexample.callback.MyActivityLifecycleCallbacks;
+import com.onecodelabs.reminderexample.model.ReminderConfig;
+import com.onecodelabs.reminderexample.remindful.PreferencesRemindfulPersister;
 import com.onecodelabs.reminderexample.remindful.RemindfulPersister;
 import com.onecodelabs.reminderexample.remindful.SqliteRemindfulPersister;
 
@@ -15,15 +18,25 @@ public class Reminder {
     private static RemindfulPersister remindfulPersister;
 
     public static void init(Application application) {
-        initRemindfulPersister(application);
+        init(application, ReminderConfig.getDefault(application));
+    }
+
+    public static void init(Application application, @NonNull ReminderConfig config) {
+        initRemindfulPersister(application, config);
         application.registerActivityLifecycleCallbacks(new ReminderActivityLifecycleCallbacks());
     }
 
-    private static void initRemindfulPersister(Application application) {
-        // TODO(gnardini): Add an optional way to set one persistence model or the other with a
-        // config object.
-        // remindfulPersister = PreferencesRemindfulPersister.init(application);
-        remindfulPersister = new SqliteRemindfulPersister(application);
+    private static void initRemindfulPersister(
+            Application application,
+            @NonNull  ReminderConfig config) {
+        switch (config.getPersistenceMode()) {
+            case SHARED_PREFERENCES:
+                remindfulPersister = PreferencesRemindfulPersister.init(application);
+                break;
+            case SQLITE:
+                remindfulPersister = new SqliteRemindfulPersister(application);
+            break;
+        }
     }
 
     public static void remind(Remindable remindable) {

--- a/reminder/src/main/java/com/onecodelabs/reminderexample/Reminder.java
+++ b/reminder/src/main/java/com/onecodelabs/reminderexample/Reminder.java
@@ -18,7 +18,7 @@ public class Reminder {
     private static RemindfulPersister remindfulPersister;
 
     public static void init(Application application) {
-        init(application, ReminderConfig.getDefault(application));
+        init(application, ReminderConfig.getDefault());
     }
 
     public static void init(Application application, @NonNull ReminderConfig config) {

--- a/reminder/src/main/java/com/onecodelabs/reminderexample/model/PersistenceMode.java
+++ b/reminder/src/main/java/com/onecodelabs/reminderexample/model/PersistenceMode.java
@@ -1,0 +1,7 @@
+package com.onecodelabs.reminderexample.model;
+
+public enum PersistenceMode {
+
+    SHARED_PREFERENCES,
+    SQLITE
+}

--- a/reminder/src/main/java/com/onecodelabs/reminderexample/model/ReminderConfig.java
+++ b/reminder/src/main/java/com/onecodelabs/reminderexample/model/ReminderConfig.java
@@ -1,0 +1,70 @@
+package com.onecodelabs.reminderexample.model;
+
+import android.app.Application;
+
+/**
+ * Object that can be used to configure Reminder options at startup (usually in an Application
+ * class).
+ */
+public class ReminderConfig {
+
+    private static final PersistenceMode DEFAULT_PERSISTENCE_MODE =
+            PersistenceMode.SHARED_PREFERENCES;
+
+    private final Application application;
+    private final PersistenceMode persistenceMode;
+
+    private ReminderConfig(Application application, PersistenceMode persistenceMode) {
+        this.application = application;
+        this.persistenceMode = persistenceMode;
+    }
+
+    public Application getApplication() {
+        return application;
+    }
+
+    public PersistenceMode getPersistenceMode() {
+        return persistenceMode;
+    }
+
+    public static ReminderConfig getDefault(Application application) {
+        return new ReminderConfig(application, DEFAULT_PERSISTENCE_MODE);
+    }
+
+    /**
+     * Builder class that creates a {@link ReminderConfig} object with the chosen configuration.
+     */
+    public static class Builder {
+
+        private Application application;
+        private PersistenceMode persistenceMode;
+
+        public Builder(Application application) {
+            this.application = application;
+        }
+
+        public ReminderConfig build() {
+            PersistenceMode persistenceMode = this.persistenceMode == null
+                    ? DEFAULT_PERSISTENCE_MODE : this.persistenceMode;
+            return new ReminderConfig(application, persistenceMode);
+        }
+
+        public Builder setPersistenceMode(PersistenceMode persistenceMode) {
+            this.persistenceMode = persistenceMode;
+            return this;
+        }
+
+        public Builder useSharedPreferences() {
+            setPersistenceMode(PersistenceMode.SHARED_PREFERENCES);
+            return this;
+        }
+
+        public Builder useSqlite() {
+            setPersistenceMode(PersistenceMode.SQLITE);
+            return this;
+        }
+
+
+    }
+
+}

--- a/reminder/src/main/java/com/onecodelabs/reminderexample/model/ReminderConfig.java
+++ b/reminder/src/main/java/com/onecodelabs/reminderexample/model/ReminderConfig.java
@@ -1,7 +1,5 @@
 package com.onecodelabs.reminderexample.model;
 
-import android.app.Application;
-
 /**
  * Object that can be used to configure Reminder options at startup (usually in an Application
  * class).
@@ -11,24 +9,18 @@ public class ReminderConfig {
     private static final PersistenceMode DEFAULT_PERSISTENCE_MODE =
             PersistenceMode.SHARED_PREFERENCES;
 
-    private final Application application;
     private final PersistenceMode persistenceMode;
 
-    private ReminderConfig(Application application, PersistenceMode persistenceMode) {
-        this.application = application;
+    private ReminderConfig(PersistenceMode persistenceMode) {
         this.persistenceMode = persistenceMode;
-    }
-
-    public Application getApplication() {
-        return application;
     }
 
     public PersistenceMode getPersistenceMode() {
         return persistenceMode;
     }
 
-    public static ReminderConfig getDefault(Application application) {
-        return new ReminderConfig(application, DEFAULT_PERSISTENCE_MODE);
+    public static ReminderConfig getDefault() {
+        return new ReminderConfig(DEFAULT_PERSISTENCE_MODE);
     }
 
     /**
@@ -36,17 +28,12 @@ public class ReminderConfig {
      */
     public static class Builder {
 
-        private Application application;
         private PersistenceMode persistenceMode;
-
-        public Builder(Application application) {
-            this.application = application;
-        }
 
         public ReminderConfig build() {
             PersistenceMode persistenceMode = this.persistenceMode == null
                     ? DEFAULT_PERSISTENCE_MODE : this.persistenceMode;
-            return new ReminderConfig(application, persistenceMode);
+            return new ReminderConfig(persistenceMode);
         }
 
         public Builder setPersistenceMode(PersistenceMode persistenceMode) {


### PR DESCRIPTION
Created a `ReminderConfig` object that can be used as a second parameter to `Reminder.init` to set which type of storage to use (SharedPreferences or SQLite). More configurations might be added there if it becomes necessary.
